### PR TITLE
Avoid leading/trailing silence in the RMS calculation

### DIFF
--- a/create_mixed_audio_file.py
+++ b/create_mixed_audio_file.py
@@ -29,6 +29,7 @@ def cal_amp(wf):
     return amptitude
 
 def cal_rms(amp):
+    amp = np.trim_zeros(amp)  # to remove leading and trailing zeros (representing silence in the audio beginning/end)
     return np.sqrt(np.mean(np.square(amp), axis=-1))
 
 def save_waveform(output_path, params, amp):


### PR DESCRIPTION
The leading and trailing zeros (to represent silence) need to be avoided while calculating the RMS of the signal, as it impacts the overall signal distortion. This is particularly important when noise-mixing is performed with clean audio signals with different lengths of silence at the start/end of the actual utterance.